### PR TITLE
Fixes #56: smart quotes cause errors in bash

### DIFF
--- a/_episodes/07-branches.md
+++ b/_episodes/07-branches.md
@@ -249,7 +249,7 @@ on it for many hours.
 ~~~
 $ touch analysis.sh
 $ git add analysis.sh
-$ git commit –m “Wrote and tested bash analysis script”
+$ git commit –m "Wrote and tested bash analysis script"
 ~~~
 {: .bash}
 

--- a/_episodes/07-branches.md
+++ b/_episodes/07-branches.md
@@ -249,7 +249,7 @@ on it for many hours.
 ~~~
 $ touch analysis.sh
 $ git add analysis.sh
-$ git commit –m "Wrote and tested bash analysis script"
+$ git commit -m "Wrote and tested bash analysis script"
 ~~~
 {: .bash}
 


### PR DESCRIPTION
Self explanatory change to sort out ASCII quotes