### PR TITLE
Fix incorrect branch name in commit output

### DIFF
--- a/episodes/08-conflict.md
+++ b/episodes/08-conflict.md
@@ -282,7 +282,7 @@ $ git commit -m "A note about Yeti's home"
 ```
 
 ```output
-[main 34avo82] A note about Yeti's home
+[marsTemp 34avo82] A note about Yeti's home
  1 file changed, 1 insertion(+)
 ```
 


### PR DESCRIPTION
I noticed the branch name was incorrect in this output of `git commit` while presenting these lessons today. We `git checkout marsTemp` then make a commit so the output of `git commit` should use the `marsTemp` branch name, not `main`.